### PR TITLE
Fix duplicate Telegram alerts

### DIFF
--- a/components/Ad.js
+++ b/components/Ad.js
@@ -53,16 +53,19 @@ class Ad {
 
     addToDataBase = async () => {
 
+        let inserted = false
+
         try {
             await adRepository.createAd(this)
             console.debug('Ad ' + this.id + ' added to the database')
+            inserted = true
         }
 
         catch (error) {
             console.debug("error: "+error)
         }
 
-        if (this.notify) {
+        if (this.notify && inserted) {
             const msg = 'Novo Anuncio encontrado!\n' + this.title + ' - R$' + this.price + '\n\n' + this.url;
             let retries = 20;
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));  // Delay function


### PR DESCRIPTION
## Summary
- avoid sending Telegram notification if ad insertion fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846233544b4832cacbcd7304b3b9829